### PR TITLE
Fixes cargo clean commands and corrects Linux path to Rust compiler

### DIFF
--- a/compilers/compiler_rust.xml
+++ b/compilers/compiler_rust.xml
@@ -10,8 +10,8 @@
             <Fallback path="C:\rust"/>
         </if>
         <else>
-            <Search path="~/.cargo"/>
-            <Fallback path="/usr/local/bin"/>
+            <Search path="/usr/"/>
+            <Fallback path="~/.cargo/"/>
         </else>
     </Path>
     <Path type="lib">

--- a/compilers/compiler_rust.xml
+++ b/compilers/compiler_rust.xml
@@ -10,9 +10,8 @@
             <Fallback path="C:\rust"/>
         </if>
         <else>
-            <Search path="/usr/local/bin"
-                    for="C"/>
-            <Fallback path="/usr"/>
+            <Search path="~/.cargo"/>
+            <Fallback path="/usr/local/bin"/>
         </else>
     </Path>
     <Path type="lib">

--- a/templates/wizard/rust/wizard.script
+++ b/templates/wizard/rust/wizard.script
@@ -121,7 +121,7 @@ function SetupProject(project)
     //setting make commands for project and targets
     project.SetMakeCommandFor(mcBuild, _T("cargo build --message-format short"));
     project.SetMakeCommandFor(mcCompileFile, _T("TODO this is not supported (yet)"));
-    project.SetMakeCommandFor(mcClean, _T("cargo clean --message-format short"));
+    project.SetMakeCommandFor(mcClean, _T("cargo clean"));
     project.SetMakeCommandFor(mcDistClean, _T("TODO this is not supported (yet)"));
 
     // enable compiler warnings (project-wide)
@@ -142,7 +142,7 @@ function SetupProject(project)
         //setting make commands for target
         debug_target.SetMakeCommandFor(mcBuild, _T("cargo build --message-format short"));
         debug_target.SetMakeCommandFor(mcCompileFile, _T("TODO this is not supported (yet)"));
-        debug_target.SetMakeCommandFor(mcClean, _T("cargo clean --message-format short"));
+        debug_target.SetMakeCommandFor(mcClean, _T("cargo clean"));
         debug_target.SetMakeCommandFor(mcDistClean, _T("TODO this is not supported (yet)"));
 
         debug_target.SetOptionRelation(ortIncludeDirs, orUseParentOptionsOnly);    
@@ -165,7 +165,7 @@ function SetupProject(project)
         //setting make commands for target
         release_target.SetMakeCommandFor(mcBuild, _T("cargo build --release --message-format short"));
         release_target.SetMakeCommandFor(mcCompileFile, _T("TODO this is not supported (yet)"));
-        release_target.SetMakeCommandFor(mcClean, _T("cargo clean --release --message-format short"));
+        release_target.SetMakeCommandFor(mcClean, _T("cargo clean --release"));
         release_target.SetMakeCommandFor(mcDistClean, _T("TODO this is not supported (yet)"));
 
         release_target.SetOptionRelation(ortIncludeDirs, orUseParentOptionsOnly);


### PR DESCRIPTION
`cargo clean` doesn't take option `--message-format short`. All instances are removed by this patch.

The standard path of the Rust compiler installed by `rustup` is patched in to help the project wizard.